### PR TITLE
fix: add more localhost checks, ipv6, full 127.x.x.x range

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const { default: ConnectionString } = require('mongodb-connection-string-url');
 
 const ATLAS_REGEX = /\.mongodb(-dev)?\.net$/i;
-const LOCALHOST_REGEX = /^(localhost|127\.0\.0\.1|0\.0\.0\.0)$/i;
+const LOCALHOST_REGEX = /^(localhost|127\.([01]?[0-9][0-9]?|2[0-4][0-9]|25[0-5])\.([01]?[0-9][0-9]?|2[0-4][0-9]|25[0-5])\.([01]?[0-9][0-9]?|2[0-4][0-9]|25[0-5])|0\.0\.0\.0|(?:0*\:)*?:?0*1)$/i;
 const DIGITAL_OCEAN_REGEX = /\.mongo\.ondigitalocean\.com$/i;
 
 function getDataLake(buildInfo) {
@@ -31,6 +31,10 @@ function isEnterprise(buildInfo) {
 }
 
 function getHostnameFromHost(host) {
+  if (host.startsWith('[')) {
+    // If it's ipv6 return what's in the brackets.
+    return host.substring(1).split(']')[0];
+  }
   return host.split(':')[0];
 }
 
@@ -41,8 +45,7 @@ function getHostnameFromUrl(url) {
 
   try {
     const connectionString = new ConnectionString(url);
-    const firstHost = connectionString.hosts[0];
-    return firstHost.split(':')[0];
+    return getHostnameFromHost(connectionString.hosts[0]);
   } catch (e) {
     // we assume is already an hostname, will further be checked against regexes
     return getHostnameFromHost(url);

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -93,6 +93,30 @@ describe('mongodb-build-info', () => {
       expect(isLocalhost('127.0.0.1:27019')).to.be.true;
     });
 
+    // Although 127.0.0.1 is usually used for localhost,
+    // anything in the 127.0.0.1 -> 127.255.255.255 can be used.
+    it('reports on localhost of type 127.x.x.x', () => {
+      expect(isLocalhost('127.0.100.1:27019')).to.be.true;
+      expect(isLocalhost('127.250.100.250:27019')).to.be.true;
+      expect(isLocalhost('127.10.0.0:27019')).to.be.true;
+    });
+
+    // IPv6 loopback addresses.
+    it('reports on localhost of type [::1]', () => {
+      expect(isLocalhost('[::1]')).to.be.true;
+      expect(isLocalhost('mongodb://[::1]/?readPreference=secondary')).to.be.true;
+      expect(isLocalhost('[0000:0000:0000:0000:0000:0000:0000:0001]')).to.be.true;
+      expect(isLocalhost('[0:0:0:0:0:0:0:1]')).to.be.true;
+      expect(isLocalhost('[0::1]')).to.be.true;
+      expect(isLocalhost('[::1]:27019')).to.be.true;
+      expect(isLocalhost('[0:0:0:0:0:0:0:1]:27019')).to.be.true;
+      expect(isLocalhost('[0::1]:27019')).to.be.true;
+    });
+
+    it('reports on localhost of type 0.0.0.0', () => {
+      expect(isLocalhost('0.0.0.0:27019')).to.be.true;
+    });
+
     it('works as url', () => {
       expect(isLocalhost('mongodb://127.0.0.1:27019')).to.be.true;
       expect(isLocalhost('mongodb+srv://127.0.0.1')).to.be.true;
@@ -109,10 +133,15 @@ describe('mongodb-build-info', () => {
     });
 
     it('does not report if localhost or 127.0.0.1 is not the hostname', () => {
-      expect(isLocalhost('127.0.0.2')).to.be.false;
+      expect(isLocalhost('127.0.0.500')).to.be.false;
+      expect(isLocalhost('128.0.0.2')).to.be.false;
       expect(isLocalhost('0.0.0.1')).to.be.false;
       expect(isLocalhost('remotehost')).to.be.false;
       expect(isLocalhost('mongodb://remotelocalhost')).to.be.false;
+      expect(isLocalhost('[test:ipv6::1]')).to.be.false;
+      expect(isLocalhost('[1:0:0:0:0:0:0:1]')).to.be.false;
+      expect(isLocalhost('[test:ipv6::1]:27019')).to.be.false;
+      expect(isLocalhost('[1:0:0:0:0:0:0:1]:27019')).to.be.false;
     });
 
     it('does not throw and returns with invalid argument', () => {


### PR DESCRIPTION
[COMPASS-5420](https://jira.mongodb.org/browse/COMPASS-5420)

This pr updates our `isLocalhost` check to:
- Include 127.x.x.x as it can be anything from `127.0.0.1` to `127.255.255.255` (previously we only checked for `127.0.0.1`.
- Include ipv6 localhost addresses (things like `::1`, `0:0:0:0:0:0:0:1`, etc)