### PR TITLE
feat: add isAtlasStream util MONGOSH-1514

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ MongoClient.connect('localhost:27017', function (err, client) {
 
   function parseCmdLineOpts (err, res) {
     if (err) console.log('Command failed', err.message)
-    
+
     const { isGenuine, serverName } = getGenuineMongoDB(buildInfo, res)
   }
 })
@@ -35,13 +35,16 @@ MongoClient.connect('localhost:27017', function (err, client) {
 ### getDataLake(buildInfo)
 Returns an object:
 
-__isDataLake__: boolean. 
+__isDataLake__: boolean.
 __dlVersion__: version of dataLake, a string.
 
 ### isEnterprise(buildInfo)
 Returns a boolean.
 
 ### isAtlas(uri)
+Returns a boolean.
+
+### isAtlasStream(uri)
 Returns a boolean.
 
 ### isLocalhost(uri)
@@ -53,7 +56,7 @@ Returns a boolean.
 ### getGenuineMongoDB(buildInfo, cmdLineOpts)
 Returns an object:
 
-__isGenuine__: boolean. 
+__isGenuine__: boolean.
 __serverName__: name of the server (mongoDB, cosmosDB, or documentDB).
 
 ### getBuildEnv(buildInfo)

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,7 @@ export declare function getDataLake(buildInfo: any): {
 
 export declare function isEnterprise(buildInfo: any): boolean;
 export declare function isAtlas(uri: string): boolean;
+export declare function isAtlasStream(uri: string): boolean;
 export declare function isLocalhost(uri: string): boolean;
 export declare function isDigitalOcean(uri: string): boolean;
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const { default: ConnectionString } = require('mongodb-connection-string-url');
 
-const ATLAS_REGEX = /\.mongodb(-dev)?\.net$/i;
+const ATLAS_REGEX = /\.mongodb(-dev|-qa|-stage)?\.net$/i;
+const ATLAS_STREAM_REGEX = /^atlas-stream-.+/i;
 const LOCALHOST_REGEX = /^(localhost|127\.([01]?[0-9][0-9]?|2[0-4][0-9]|25[0-5])\.([01]?[0-9][0-9]?|2[0-4][0-9]|25[0-5])\.([01]?[0-9][0-9]?|2[0-4][0-9]|25[0-5])|0\.0\.0\.0|(?:0*\:)*?:?0*1)$/i;
 const DIGITAL_OCEAN_REGEX = /\.mongo\.ondigitalocean\.com$/i;
 
@@ -56,6 +57,11 @@ function isAtlas(uri) {
   return !!getHostnameFromUrl(uri).match(ATLAS_REGEX);
 }
 
+function isAtlasStream(uri) {
+  const host = getHostnameFromUrl(uri);
+  return !!(host.match(ATLAS_REGEX) && host.match(ATLAS_STREAM_REGEX));
+}
+
 function isLocalhost(uri) {
   return !!getHostnameFromUrl(uri).match(LOCALHOST_REGEX);
 }
@@ -97,4 +103,4 @@ function getGenuineMongoDB(buildInfo, cmdLineOpts) {
   return res;
 }
 
-module.exports = { getDataLake, isEnterprise, isAtlas, isLocalhost, isDigitalOcean, getGenuineMongoDB, getBuildEnv };
+module.exports = { getDataLake, isEnterprise, isAtlas, isAtlasStream, isLocalhost, isDigitalOcean, getGenuineMongoDB, getBuildEnv };

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,6 +1,7 @@
 const expect = require('chai').expect;
 const fixtures = require('./fixtures');
 const isAtlas = require('../.').isAtlas;
+const isAtlasStream = require('../.').isAtlasStream;
 const getDataLake = require('../.').getDataLake;
 const isLocalhost = require('../.').isLocalhost;
 const isDigitalOcean = require('../.').isDigitalOcean;
@@ -67,6 +68,16 @@ describe('mongodb-build-info', () => {
       expect(isAtlas('cat-data-sets.cats.mongodb-dev.net')).to.be.true;
     });
 
+    it('returns true with atlas qa', () => {
+      expect(isAtlas('mongodb+srv://admin:catscatscats@cat-data-sets.cats.mongodb-qa.net/admin')).to.be.true;
+      expect(isAtlas('cat-data-sets.cats.mongodb-qa.net')).to.be.true;
+    });
+
+    it('returns true with atlas staging', () => {
+      expect(isAtlas('mongodb+srv://admin:catscatscats@cat-data-sets.cats.mongodb-stage.net/admin')).to.be.true;
+      expect(isAtlas('cat-data-sets.cats.mongodb-stage.net')).to.be.true;
+    });
+
     it('returns false if not atlas', () => {
       expect(isAtlas('cat-data-sets.cats.mangodb.net')).to.be.false;
       expect(isAtlas('cat-data-sets.catsmongodb.net')).to.be.false;
@@ -81,6 +92,52 @@ describe('mongodb-build-info', () => {
       expect(isAtlas({})).to.be.false;
       expect(isAtlas(undefined)).to.be.false;
       expect(isAtlas(null)).to.be.false;
+    });
+  });
+
+  context('isAtlasStream', () => {
+    it('reports on atlas', () => {
+      expect(isAtlasStream('mongodb://admin:catscatscats@atlas-stream-64ba1372b2a9f1545031f34d-gkumd.virginia-usa.a.query.mongodb.net/')).to.be.true;
+      expect(isAtlasStream('mongodb://admin:catscatscats@atlas-stream-64ba1372b2a9f1545031f34d-gkumd.virginia-usa.a.query.mongodb.net/')).to.be.true;
+    });
+
+    it('works with host only', () => {
+      expect(isAtlasStream('atlas-stream-64ba1372b2a9f1545031f34d-gkumd.virginia-usa.a.query.mongodb.net:27017')).to.be.true;
+    });
+
+    it('works with hostname', () => {
+      expect(isAtlasStream('atlas-stream-64ba1372b2a9f1545031f34d-gkumd.virginia-usa.a.query.mongodb.net')).to.be.true;
+    });
+
+    it('returns true with atlas dev', () => {
+      expect(isAtlasStream('mongodb://admin:catscatscats@atlas-stream-64ba1372b2a9f1545031f34d-gkumd.virginia-usa.a.query.mongodb-dev.net/')).to.be.true;
+      expect(isAtlasStream('atlas-stream-64ba1372b2a9f1545031f34d-gkumd.virginia-usa.a.query.mongodb-dev.net')).to.be.true;
+    });
+
+    it('returns true with atlas qa', () => {
+      expect(isAtlasStream('mongodb://admin:catscatscats@atlas-stream-64ba1372b2a9f1545031f34d-gkumd.virginia-usa.a.query.mongodb-qa.net/')).to.be.true;
+      expect(isAtlasStream('atlas-stream-64ba1372b2a9f1545031f34d-gkumd.virginia-usa.a.query.mongodb-qa.net')).to.be.true;
+    });
+
+    it('returns true with atlas staging', () => {
+      expect(isAtlasStream('mongodb://admin:catscatscats@atlas-stream-64ba1372b2a9f1545031f34d-gkumd.virginia-usa.a.query.mongodb-stage.net/')).to.be.true;
+      expect(isAtlasStream('atlas-stream-64ba1372b2a9f1545031f34d-gkumd.virginia-usa.a.query.mongodb-stage.net')).to.be.true;
+    });
+
+    it('returns false if not atlas stream', () => {
+      expect(isAtlasStream('cat-data-sets.cats.mangodb.net')).to.be.false;
+      expect(isAtlasStream('cat-data-sets.catsmongodb.net')).to.be.false;
+      expect(isAtlasStream('cat-data-sets.cats.mongodb.netx')).to.be.false;
+      expect(isAtlasStream('cat-data-sets.cats.mongodb.com')).to.be.false;
+      expect(isAtlasStream('localhost')).to.be.false;
+    });
+
+    it('does not throw and returns with invalid argument', () => {
+      expect(isAtlasStream(123)).to.be.false;
+      expect(isAtlasStream('')).to.be.false;
+      expect(isAtlasStream({})).to.be.false;
+      expect(isAtlasStream(undefined)).to.be.false;
+      expect(isAtlasStream(null)).to.be.false;
     });
   });
 


### PR DESCRIPTION
- adds a new util `isAtlasStream`
- ATLAS_REGEX now also matches qa and staging hostnames